### PR TITLE
Fixing bug in Adding dns zone for reverse dns entry task

### DIFF
--- a/Ansible/roles/server-freeipa/tasks/main.yml
+++ b/Ansible/roles/server-freeipa/tasks/main.yml
@@ -177,7 +177,7 @@
     ipa_timeout: 30
     validate_certs: no
   register: dns_reverse_zone
-  failed_when: "'no modification to be performed' not in dns_reverse_zone.msg"
+  failed_when: "'no modifications to be performed' not in dns_reverse_zone.msg"
   become: true
 
 - name: Creating PTR record for a reverse DNS record...


### PR DESCRIPTION
This MR fixes a small bug in the server-freeipa task "Adding dns zone for reverse dns entry" task.