### PR TITLE
Chore/update server apps and tooling

### DIFF
--- a/Ansible/roles/app-cilium-cli/vars/main.yml
+++ b/Ansible/roles/app-cilium-cli/vars/main.yml
@@ -1,13 +1,13 @@
 ---
-cilium_cli_ver: 'v0.18.2'
+cilium_cli_ver: 'v0.18.3'
 
 cilium_cli_install_dir: /usr/local/bin
 
 cilium_cli_force_update: false
 
-#https://github.com/cilium/cilium-cli/releases/tag/v0.18.2
-#https://github.com/cilium/cilium-cli/releases/download/v0.18.2/cilium-linux-amd64.tar.gz
+#https://github.com/cilium/cilium-cli/releases/tag/v0.18.3
+#https://github.com/cilium/cilium-cli/releases/download/v0.18.3/cilium-linux-amd64.tar.gz
 cilium_cli_download_url: 'https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_ver }}/cilium-linux-amd64.tar.gz'
 
-#https://github.com/cilium/cilium-cli/releases/download/v0.18.2/cilium-linux-amd64.tar.gz.sha256sum
-cilium_cli_checksum: sha256:1b4bd5fd5c96ab1195cd4eb56841c983a21149c62ee39922b7955f1cd0eda23a
+#https://github.com/cilium/cilium-cli/releases/download/v0.18.3/cilium-linux-amd64.tar.gz.sha256sum
+cilium_cli_checksum: sha256:5fe565f3b98b5846b867319aa76bc057fca37894d80db56edc20e4e809d10b25

--- a/Ansible/roles/app-cosign/vars/main.yml
+++ b/Ansible/roles/app-cosign/vars/main.yml
@@ -2,6 +2,8 @@
 #--------------------------------------------------------------
 # COSIGN SPECIFIC VARS
 #--------------------------------------------------------------
+# Cosign Version
+cosign_version: "v2.5.0"
 # Directory
 cosign_dir: "/opt/cosign"
 
@@ -9,6 +11,6 @@ cosign_dir: "/opt/cosign"
 cosign_binary: "cosign-linux-amd64"
 
 # URLS
-cosign_github_url: "https://github.com/sigstore/cosign/releases/latest/download"
+cosign_github_url: "https://github.com/sigstore/cosign/releases/download/{{ cosign_version }}"
 
 

--- a/Ansible/roles/app-helm/vars/main.yml
+++ b/Ansible/roles/app-helm/vars/main.yml
@@ -1,13 +1,13 @@
 ---
-helm_ver: 'v3.17.2'
+helm_ver: 'v3.17.3'
 
 helm_install_dir: /usr/local/bin
 
 helm_force_update: false
 
 #https://github.com/helm/helm/tags
-# https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz
+# https://get.helm.sh/helm-v3.17.3-linux-amd64.tar.gz
 helm_download_url: 'https://get.helm.sh/helm-{{ helm_ver }}-linux-amd64.tar.gz'
 
-# https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz.sha256sum
-helm_checksum: sha256:90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241
+# https://get.helm.sh/helm-v3.17.3-linux-amd64.tar.gz.sha256sum
+helm_checksum: sha256:ee88b3c851ae6466a3de507f7be73fe94d54cbf2987cbaa3d1a3832ea331f2cd

--- a/Ansible/roles/app-hubble-cli/vars/main.yml
+++ b/Ansible/roles/app-hubble-cli/vars/main.yml
@@ -1,13 +1,13 @@
 ---
-hubble_cli_ver: 'v1.17.1'
+hubble_cli_ver: 'v1.17.2'
 
 hubble_cli_install_dir: /usr/local/bin
 
 hubble_cli_force_update: false
 
-#https://github.com/cilium/hubble/releases/tag/v1.17.1
+#https://github.com/cilium/hubble/releases/tag/v1.17.2
 #https://github.com/cilium/cilium-cli/releases/download/v0.16.24/cilium-linux-amd64.tar.gz
 hubble_cli_download_url: 'https://github.com/cilium/hubble/releases/download/{{ hubble_cli_ver }}/hubble-linux-amd64.tar.gz'
 
-#https://github.com/cilium/hubble/releases/download/v1.17.1/hubble-linux-amd64.tar.gz.sha256sum
-hubble_cli_checksum: sha256:1fa643076206df77be36fab8eaf900bd8bf9cf2dd479e13bdb2a5af98335e530
+#https://github.com/cilium/hubble/releases/download/v1.17.2/hubble-linux-amd64.tar.gz.sha256sum
+hubble_cli_checksum: sha256:b048e73ee39ce1a46730460362afb14e08cf9edf2c541ab9dd8f2aadcb350ddc

--- a/Ansible/roles/app-kubectl/vars/main.yml
+++ b/Ansible/roles/app-kubectl/vars/main.yml
@@ -2,9 +2,9 @@
 kubectl_force_update: false
 
 #https://kubernetes.io/releases/
-kubectl_ver: 'v1.32.2'
+kubectl_ver: 'v1.32.3'
 
-#https://dl.k8s.io/v1.32.2/kubernetes-client-linux-amd64.tar.gz
+#https://dl.k8s.io/v1.32.3/kubernetes-client-linux-amd64.tar.gz
 kubectl_download_url: 'https://dl.k8s.io/{{ kubectl_ver }}/kubernetes-client-linux-amd64.tar.gz'
 
 kubectl_install_dir: '/usr/local/bin'

--- a/Ansible/roles/app-kubelogin/vars/main.yml
+++ b/Ansible/roles/app-kubelogin/vars/main.yml
@@ -2,7 +2,7 @@
 kubelogin_force_update: false
 
 #https://kubernetes.io/releases/
-kubelogin_ver: 'v1.32.2' #in lock steps with the Kubernetes version
+kubelogin_ver: 'v1.32.3' #in lock steps with the Kubernetes version
 
 #https://github.com/int128/kubelogin/releases/download/v1.32.2/kubelogin_linux_amd64.zip
 kubelogin_download_url: 'https://github.com/int128/kubelogin/releases/download/{{ kubelogin_ver }}/kubelogin_linux_amd64.zip'
@@ -11,5 +11,5 @@ kubectl_install_dir: '/usr/local/bin'
 
 kubelogin_install_dir: '/usr/local/bin'
 
-#https://github.com/int128/kubelogin/releases/download/v1.32.2/kubelogin_linux_amd64.zip.sha256
-kubelogin_checksum: sha256:83cd392b0b53cbf4335e3fdbbef6ca1eb26831fb37369e9759169954ea8f7b7b
+#https://github.com/int128/kubelogin/releases/download/v1.32.3/kubelogin_linux_amd64.zip.sha256
+kubelogin_checksum: sha256:c065f95401f96e548a835838aaf0834dba9d347a0e5af2f38664272a66e2d948

--- a/Ansible/roles/app-kubescape/vars/main.yml
+++ b/Ansible/roles/app-kubescape/vars/main.yml
@@ -1,13 +1,13 @@
 ---
-kubescape_ver: '3.0.30'
+kubescape_ver: '3.0.34'
 
 kubescape_install_dir: /usr/local/bin
 
 kubescape_force_update: false
 
-#https://github.com/kubescape/kubescape/releases/tag/v3.0.30
-#https://github.com/kubescape/kubescape/releases/download/v3.0.30/kubescape-ubuntu-latest.tar.gz
+#https://github.com/kubescape/kubescape/releases/tag/v3.0.34
+#https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-ubuntu-latest.tar.gz
 kubescape_download_url: 'https://github.com/kubescape/kubescape/releases/download/v{{ kubescape_ver }}/kubescape-ubuntu-latest.tar.gz'
 
-#https://github.com/kubescape/kubescape/releases/download/v3.0.30/kubescape-ubuntu-latest.sha256
-kubescape_checksum: sha256:e48c0ad6bab27b80a638084951ad80c956778d5e8a839acf4688a11f62de6e38
+#https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-ubuntu-latest.sha256
+kubescape_checksum: sha256:04f0a9af0a0884e17ce782c571ccf1a2f8e4d69e46405fd08836bb8a51dc482b

--- a/Ansible/roles/app-sops/vars/main.yml
+++ b/Ansible/roles/app-sops/vars/main.yml
@@ -2,12 +2,12 @@
 sops_force_update: false
 
 #https://github.com/getsops/sops/releases
-sops_ver: 'v3.9.4'
+sops_ver: 'v3.10.2'
 
-#https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
+#https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.amd64
 sops_download_url: 'https://github.com/getsops/sops/releases/download/{{ sops_ver }}/sops-{{ sops_ver }}.linux.amd64'
 
-#https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.checksums.txt
-sops_checksum: sha256:5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85
+#https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.checksums.txt
+sops_checksum: sha256:79b0f844237bd4b0446e4dc884dbc1765fc7dedc3968f743d5949c6f2e701739
 
 sops_install_dir: '/usr/local/bin'

--- a/Ansible/roles/app-talos-cli/vars/main.yml
+++ b/Ansible/roles/app-talos-cli/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-talosctl_version: 'v1.9.4'
+talosctl_version: 'v1.9.5'
 
 os_arch: 'linux-amd64'
 
@@ -7,8 +7,8 @@ talosctl_install_dir: /usr/local/bin
 
 talosctl_force_update: false
 
-#https://github.com/siderolabs/talos/releases/download/v1.9.4/talosctl-linux-amd64
+#https://github.com/siderolabs/talos/releases/download/v1.9.5/talosctl-linux-amd64
 talosctl_download_url: 'https://github.com/siderolabs/talos/releases/download/{{ talosctl_version }}/talosctl-{{ os_arch }}'
 
-# https://github.com/siderolabs/talos/releases/download/v1.9.4/sha256sum.txt
-talosctl_checksum: sha256:fba0da733c58767df54267817a8594de5b213f093536c806d3a62f43a16addce
+# https://github.com/siderolabs/talos/releases/download/v1.9.5/sha256sum.txt
+talosctl_checksum: sha256:085b089dfd2c28dbe9489ff218abd1f6ea4ad8520c34b162d079ba5b45ccda62

--- a/Ansible/roles/app-trivy/vars/main.yml
+++ b/Ansible/roles/app-trivy/vars/main.yml
@@ -1,8 +1,8 @@
 ---
-trivy_version: '0.60.0'
+trivy_version: '0.61.1'
 
-# https://github.com/aquasecurity/trivy/releases/tag/v0.60.0
+# https://github.com/aquasecurity/trivy/releases/tag/v0.61.1
 trivy_download_url: 'https://github.com/aquasecurity/trivy/releases/download/v{{ trivy_version }}/trivy_{{ trivy_version }}_Linux-64bit.rpm'
 
-# https://github.com/aquasecurity/trivy/releases/download/v0.60.0/trivy_0.60.0_checksums.txt
-trivy_checksum: sha256:e122d727b398f53dd742aeaa5bbbc2d565d202b092a57dbbd2a40dfbdf4b29e8
+# https://github.com/aquasecurity/trivy/releases/download/v0.61.1/trivy_0.61.1_checksums.txt
+trivy_checksum: sha256:ec3166c345a3bb8772cdcd65e46f6ab5a4c8020684abb7b70fcbcacbefc99c88

--- a/Ansible/roles/app-vscode/vars/main.yml
+++ b/Ansible/roles/app-vscode/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 #https://packages.microsoft.com/yumrepos/vscode/
-vscode_package: "https://packages.microsoft.com/yumrepos/vscode/Packages/c/code-1.98.1-1741624570.el8.x86_64.rpm"
+vscode_package: "https://packages.microsoft.com/yumrepos/vscode/Packages/c/code-1.99.3-1744761644.el8.x86_64.rpm"
 vscode_checksums:
   # https://code.visualstudio.com/download
   '1.98.1':
     # https://packages.microsoft.com/yumrepos/vscode/Packages/c/
-    linux_64bit-rpm: sha256:eac6c6833e1050f401bb4564f92b3c922b4cdf1d19b3b84bc8bad6332a5ea9de
+    linux_64bit-rpm: sha256:5bad360e7df1535809b5df787bb1c16934ba545bde5c3f65e874269bcca4f20a

--- a/Ansible/roles/webapp-evoharbor/vars/main.yml
+++ b/Ansible/roles/webapp-evoharbor/vars/main.yml
@@ -18,6 +18,9 @@ ldap_dc: "dc={{ domain_tld.split('.')[0] }},dc={{ domain_tld.split('.')[1] }}"
 #--------------------------------------------------------------
 # HARBOR SPECIFIC VARS
 #--------------------------------------------------------------
+# Harbor Version
+harbor_version: "v2.13.0"
+
 evoharbor_force_update: false
 
 # Directories
@@ -28,9 +31,6 @@ harbor_cert_dir: "/data/cert"
 
 # Harbor Password
 harbor_admin_passwd: "{{ creds_store.code_harbor_passwd }}"
-
-# Harbor Version
-harbor_version: "v2.12.2"
 
 # Packages
 harbor_installer: "harbor-online-installer-{{ harbor_version }}.tgz"


### PR DESCRIPTION
Updates for Server based apps and tooling
cilium updated to 1.18.3
cosign updated to 2.5.0
helm updated to 3.17.3
hubble updated to 1.17.2
kubectl updated to 1.32.3
kubelogin updated to 1.32.3
kubescape updated to 3.0.34
sops updated to 3.10.2
talosctl updated to 1.9.5
trivy updated to 0.61.1
vscode updated to 1.99.3
harbor updated to 2.13.0