### PR TITLE
Fixed syntax in dockerfile and removed default task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p $HOMEDIR/{Keys,Logs,Ansible} && \
     curl -L -k "https://github.com/evocloud-dev/evocloud-paas/archive/refs/tags/v$PAAS_VERSION.tar.gz" > "/tmp/evocloud-$PAAS_VERSION.tar.gz" && \
     tar -xzf /tmp/evocloud-$PAAS_VERSION.tar.gz --strip-components=1 -C $HOMEDIR && \
     rm -rf /tmp/* && \
-    chmod 0660 $HOMEDIR/Logs && \
+    chmod 0660 $HOMEDIR/Logs
 
 WORKDIR $HOMEDIR
 ENTRYPOINT ["task"]
-CMD ["copy-files"]


### PR DESCRIPTION
Fixed dockerfile syntax that caused an error with the WORKDIR instruction.

I removed the default task because if they don't pass any command to the taskfile, it will default to printing out the list of available tasks.  Printing out the list of available tasks feels right to me.