### PR TITLE
Bugfix/copy ansible cfg

### DIFF
--- a/Ansible/roles/app-ansible/tasks/main.yml
+++ b/Ansible/roles/app-ansible/tasks/main.yml
@@ -28,10 +28,16 @@
 
 - name: Copy ansible.cfg to /etc/ansible
   ansible.builtin.copy:
-    src: "/home/{{ cloud_user }}/ansible.cfg"
+    src: "/tmp/ansible.cfg"
     dest: "/etc/ansible/ansible.cfg"
     owner: root
     group: root
     mode: '0644'
     remote_src: yes
+  become: true
+
+- name: Remove ansible.cfg in /tmp
+  ansible.builtin.file:
+    path: /tmp/ansible.cfg
+    state: absent
   become: true

--- a/Ansible/roles/app-ansible/vars/main.yml
+++ b/Ansible/roles/app-ansible/vars/main.yml
@@ -1,3 +1,5 @@
 ---
+cloud_user: ''
+
 required_packages:
   - ansible

--- a/Terraform/gcp/compose/server-dmz-deployer/main.tf
+++ b/Terraform/gcp/compose/server-dmz-deployer/main.tf
@@ -96,7 +96,7 @@ resource "terraform_data" "staging_automation_code" {
 
   provisioner "file" {
     source        = "/etc/ansible/ansible.cfg"
-    destination   = "/home/${var.CLOUD_USER}/ansible.cfg"
+    destination   = "/tmp/ansible.cfg"
   }
 
   provisioner "file" {


### PR DESCRIPTION
app-ansible was failing for unable to find /home//ansible.cfg.  I moved ansible.cfg to /tmp because cloud-user variable wasn't expanding properly.  Tested code and everything is good to go.

We now get ansible profiling details on downstream VMs.