### PR TITLE
Updating helper files to align with updates to terragrunt software

### DIFF
--- a/Terraform/gcp/compose/cluster-admin-talos-helper/main.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/cluster-admin-talos",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/cluster-talos-standalone-helper/main.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evotalos_standalone_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/cluster-talos-standalone",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-admin-idam-helper/main.tf
+++ b/Terraform/gcp/compose/server-admin-idam-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-02-admin-idam",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-admin-idam_replica-helper/main.tf
+++ b/Terraform/gcp/compose/server-admin-idam_replica-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam-replica_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-03-admin-idam_replica",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-backend-evocode-helper/main.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam-replica_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-backend-evocode",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-backend-evocode-runner-helper/main.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam-replica_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-backend-evocode-runner",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-backend-evoharbor-helper/main.tf
+++ b/Terraform/gcp/compose/server-backend-evoharbor-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam-replica_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-backend-evoharbor",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-dmz-rdp-helper/main.tf
+++ b/Terraform/gcp/compose/server-dmz-rdp-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "rdp_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-dmz-rdp",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/gcp/compose/server-dmz-vcd-helper/main.tf
+++ b/Terraform/gcp/compose/server-dmz-vcd-helper/main.tf
@@ -23,7 +23,7 @@ resource "terraform_data" "evoidam-replica_deployment" {
       "export GOOGLE_APPLICATION_CREDENTIALS='/home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}'",
       "gcloud auth activate-service-account --key-file /home/${var.CLOUD_USER}/EVOCLOUD/Keys/${var.GCP_JSON_CREDS}",
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/gcp/deployment/server-dmz-vcd",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/cluster-admin-talos-helper/main.tf
+++ b/Terraform/oci/compose/cluster-admin-talos-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/cluster-admin-talos",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/cluster-talos-standalone-helper/main.tf
+++ b/Terraform/oci/compose/cluster-talos-standalone-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/cluster-talos-standalone",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-admin-idam-helper/main.tf
+++ b/Terraform/oci/compose/server-admin-idam-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-02-admin-idam",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-admin-idam_replica-helper/main.tf
+++ b/Terraform/oci/compose/server-admin-idam_replica-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-03-admin-idam_replica",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-backend-evocode-helper/main.tf
+++ b/Terraform/oci/compose/server-backend-evocode-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-backend-evocode",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-backend-evocode-runner-helper/main.tf
+++ b/Terraform/oci/compose/server-backend-evocode-runner-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-backend-evocode-runner",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-backend-evoharbor-helper/main.tf
+++ b/Terraform/oci/compose/server-backend-evoharbor-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-backend-evoharbor",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-dmz-rdp-helper/main.tf
+++ b/Terraform/oci/compose/server-dmz-rdp-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-dmz-rdp",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }

--- a/Terraform/oci/compose/server-dmz-vcd-helper/main.tf
+++ b/Terraform/oci/compose/server-dmz-vcd-helper/main.tf
@@ -21,7 +21,7 @@ resource "terraform_data" "evotalos_cluster_deployment" {
   provisioner "remote-exec" {
     inline = [
       "cd /home/${var.CLOUD_USER}/EVOCLOUD/Terraform/oci/deployment/server-dmz-vcd",
-      "terragrunt run-all apply --non-interactive --queue-include-external -auto-approve",
+      "terragrunt run --all apply --non-interactive --queue-include-external",
     ]
   }
 }


### PR DESCRIPTION
Updating terraform code to better align with changes to terragrunt updates.
The new run --all apply command when used with --queue-include-external automatically applies the -auto-approve according to the docs. 

I hit a failure during deployment to GCP and this was the required fix.