### PR TITLE
Updating GCP code to eliminate gcloud cli dependency

### DIFF
--- a/Terraform/gcp/Taskfile.yaml
+++ b/Terraform/gcp/Taskfile.yaml
@@ -5,7 +5,6 @@ silent: true
 vars:
   # Common across tasks
   DEPLOY_DIR:          "/opt/EVOCLOUD/Terraform/gcp/deployment"
-  GCLOUD_AUTH:         "gcloud auth activate-service-account --key-file"
   GCLOUD_EXPORT:       "export GOOGLE_APPLICATION_CREDENTIALS"
   KEYS_DIR:            "/opt/EVOCLOUD/Keys"
   BUILD_CMD:           "terragrunt run --all --non-interactive --queue-include-external apply -- -auto-approve"
@@ -22,7 +21,6 @@ tasks:
     internal: true
     cmds:
       - |
-        {{.GCLOUD_AUTH}} {{.KEYS_DIR}}/{{.KEYFILE}} && \
         {{.GCLOUD_EXPORT}}={{.KEYS_DIR}}/{{.KEYFILE}} && \
         cd {{.DEPLOY_DIR}}/{{.SERVER}}/ && \
         {{.ACTION}}  

--- a/Terraform/gcp/compose/cluster-admin-talos-helper-destroy/providers.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos-helper-destroy/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-admin-talos-helper-destroy/variables.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos-helper-destroy/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/cluster-admin-talos-helper/providers.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-admin-talos-helper/variables.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/cluster-admin-talos/providers.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-admin-talos/variables.tf
+++ b/Terraform/gcp/compose/cluster-admin-talos/variables.tf
@@ -151,6 +151,11 @@ variable "ADMIN_SUBNET_CIDR_LBIPAM" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/cluster-talos-standalone-helper-destroy/providers.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone-helper-destroy/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-talos-standalone-helper-destroy/variables.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone-helper-destroy/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/cluster-talos-standalone-helper/providers.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-talos-standalone-helper/variables.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/cluster-talos-standalone/providers.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/cluster-talos-standalone/variables.tf
+++ b/Terraform/gcp/compose/cluster-talos-standalone/variables.tf
@@ -1,3 +1,13 @@
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}
+
 variable "GCP_REGION" {
   description = "GCP Region"
   type        = string

--- a/Terraform/gcp/compose/kubeapp-flux/providers.tf
+++ b/Terraform/gcp/compose/kubeapp-flux/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/kubeapp-flux/variables.tf
+++ b/Terraform/gcp/compose/kubeapp-flux/variables.tf
@@ -23,6 +23,16 @@ variable "ANSIBLE_DEBUG_FLAG" {
   type        = bool
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}
+
 variable "deployer_server_eip" {
   description = "Deployer Server Public IP"
   type        = string

--- a/Terraform/gcp/compose/network-gateway/provider.tf
+++ b/Terraform/gcp/compose/network-gateway/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/network-gateway/variables.tf
+++ b/Terraform/gcp/compose/network-gateway/variables.tf
@@ -12,3 +12,13 @@ variable "GCP_VPC" {
   description = "Main VPC Name"
   type        = string
 }
+
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/network-subnet/provider.tf
+++ b/Terraform/gcp/compose/network-subnet/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/network-subnet/variables.tf
+++ b/Terraform/gcp/compose/network-subnet/variables.tf
@@ -32,3 +32,13 @@ variable "ADMIN_SUBNET_CIDR_LBIPAM" {
   description = "ADMIN Subnet CIDR for Cilium Loadbalancer LB-IPAM"
   type        = string
 }
+
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/network-vpc/provider.tf
+++ b/Terraform/gcp/compose/network-vpc/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/network-vpc/variables.tf
+++ b/Terraform/gcp/compose/network-vpc/variables.tf
@@ -47,3 +47,13 @@ variable "IDAM_PRIVATE_IP" {
   description = "IDAM Private IPv4"
   type        = string
 }
+
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-admin-idam-helper/providers.tf
+++ b/Terraform/gcp/compose/server-admin-idam-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-admin-idam-helper/variables.tf
+++ b/Terraform/gcp/compose/server-admin-idam-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-admin-idam/provider.tf
+++ b/Terraform/gcp/compose/server-admin-idam/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-admin-idam/variables.tf
+++ b/Terraform/gcp/compose/server-admin-idam/variables.tf
@@ -83,6 +83,11 @@ variable "IDAM_REPLICA_PRIVATE_IP" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-admin-idam_replica-helper/providers.tf
+++ b/Terraform/gcp/compose/server-admin-idam_replica-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-admin-idam_replica-helper/variables.tf
+++ b/Terraform/gcp/compose/server-admin-idam_replica-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-admin-idam_replica/provider.tf
+++ b/Terraform/gcp/compose/server-admin-idam_replica/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-admin-idam_replica/variables.tf
+++ b/Terraform/gcp/compose/server-admin-idam_replica/variables.tf
@@ -98,6 +98,11 @@ variable "CLOUD_PLATFORM" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-backend-evocode-group/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-group/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode-group/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-group/variables.tf
@@ -23,6 +23,16 @@ variable "ANSIBLE_DEBUG_FLAG" {
   type        = bool
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}
+
 variable "deployer_server_eip" {
   description = "Deployer Server Public IP"
   type        = string

--- a/Terraform/gcp/compose/server-backend-evocode-helper/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode-helper/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-backend-evocode-runner-helper/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode-runner-helper/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-backend-evocode-runner-registration/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner-registration/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode-runner-registration/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner-registration/variables.tf
@@ -38,6 +38,11 @@ variable "ANSIBLE_DEBUG_FLAG" {
   type        = bool
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "idam_server_ip" {
   description = "IDAM Server Private IPv4"
   type        = string

--- a/Terraform/gcp/compose/server-backend-evocode-runner/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode-runner/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode-runner/variables.tf
@@ -83,6 +83,11 @@ variable "GCP_METADATA_NS" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-backend-evocode/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evocode/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evocode/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evocode/variables.tf
@@ -83,6 +83,11 @@ variable "GCP_METADATA_NS" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-backend-evoharbor-helper/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evoharbor-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evoharbor-helper/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evoharbor-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-backend-evoharbor/providers.tf
+++ b/Terraform/gcp/compose/server-backend-evoharbor/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-backend-evoharbor/variables.tf
+++ b/Terraform/gcp/compose/server-backend-evoharbor/variables.tf
@@ -83,6 +83,11 @@ variable "GCP_METADATA_NS" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-dmz-deployer-idpclient/providers.tf
+++ b/Terraform/gcp/compose/server-dmz-deployer-idpclient/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-deployer-idpclient/variables.tf
+++ b/Terraform/gcp/compose/server-dmz-deployer-idpclient/variables.tf
@@ -53,6 +53,11 @@ variable "GCP_METADATA_NS" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "deployer_server_eip" {
   description = "Deployer Server Public IP"
   type        = string

--- a/Terraform/gcp/compose/server-dmz-deployer/provider.tf
+++ b/Terraform/gcp/compose/server-dmz-deployer/provider.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-rdp-helper/providers.tf
+++ b/Terraform/gcp/compose/server-dmz-rdp-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-rdp-helper/variables.tf
+++ b/Terraform/gcp/compose/server-dmz-rdp-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-dmz-rdp/providers.tf
+++ b/Terraform/gcp/compose/server-dmz-rdp/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-rdp/variables.tf
+++ b/Terraform/gcp/compose/server-dmz-rdp/variables.tf
@@ -88,6 +88,11 @@ variable "CLOUD_PLATFORM" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool

--- a/Terraform/gcp/compose/server-dmz-vcd-helper/providers.tf
+++ b/Terraform/gcp/compose/server-dmz-vcd-helper/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-vcd-helper/variables.tf
+++ b/Terraform/gcp/compose/server-dmz-vcd-helper/variables.tf
@@ -27,3 +27,8 @@ variable "GCP_JSON_CREDS" {
   description = "GCP Secret Json Key File"
   type        = string
 }
+
+variable "AUTOMATION_FOLDER" {
+  description = "Automation Folder"
+  type        = string
+}

--- a/Terraform/gcp/compose/server-dmz-vcd/providers.tf
+++ b/Terraform/gcp/compose/server-dmz-vcd/providers.tf
@@ -2,7 +2,7 @@
 # Supported Cloud Provider
 #--------------------------------------------------
 provider "google" {
-  #credentials = file("path/to/credentials.json")
+  credentials = file("${var.AUTOMATION_FOLDER}/Keys/${var.GCP_JSON_CREDS}")
   project = var.GCP_PROJECT_ID
   region  = var.GCP_REGION
 }

--- a/Terraform/gcp/compose/server-dmz-vcd/variables.tf
+++ b/Terraform/gcp/compose/server-dmz-vcd/variables.tf
@@ -88,6 +88,11 @@ variable "CLOUD_PLATFORM" {
   type        = string
 }
 
+variable "GCP_JSON_CREDS" {
+  description = "GCP Secret Json Key File"
+  type        = string
+}
+
 variable "use_spot" {
   description = "Use Ephemeral VM Instances that can be Terminated"
   type        = bool


### PR DESCRIPTION
Eliminates need for gcloud cli for deployments. This is part of the effort to shrink the size of the evo-deployer container.